### PR TITLE
No need to force_encoding if already in a UTF-8 Environment

### DIFF
--- a/lib/scarlet/connection.rb
+++ b/lib/scarlet/connection.rb
@@ -31,7 +31,7 @@ class Scarlet::Connection < EM::Connection
   # @param [String] line The line that was recieved from the server.
   def receive_line line
     reset_check_connection_timer
-    @server.receive_line line.force_encoding('utf-8')
+    @server.receive_line line
   end
 
   # Sends data back to the server, using the carriage return as an escape symbol


### PR DESCRIPTION
Funny, how this fix is a 1 line change.