### PR TITLE
Hitch-hike the Command plugin on the Event

### DIFF
--- a/commands/bot.rb
+++ b/commands/bot.rb
@@ -21,7 +21,7 @@ hear (/reload commands/i) do
   description 'Loads all available commands.'
   usage 'reload commands'
   on do
-    if Scarlet::Command.load_commands
+    if event.data[:commands].load_commands
       notify "Commands loaded."
     else
       notify "Command loading failed."
@@ -36,7 +36,7 @@ hear (/reload command\s+(\w+)/i) do
   on do
     filename = File.basename(params[0])
     begin
-      Scarlet::Command.load_command_rel(filename)
+      event.data[:commands].load_command_rel(filename)
       notify "Command #{filename} loaded."
     rescue => ex
       notify "Command #{filename} load error: #{ex.inspect}"

--- a/commands/help.rb
+++ b/commands/help.rb
@@ -4,11 +4,11 @@ hear (/help(?:\s*(?<query>.*))/i) do
   usage 'help [<query>]'
   on do
     query = params[:query].presence
-    commands = Scarlet::Command.get_help(query)
-    if commands.blank?
+    helps = event.data[:commands].get_help(query)
+    if helps.blank?
       reply "I'm sorry I didn't find a (#{query}) command that matched."
     else
-      commands.each do |line|
+      helps.each do |line|
         notify line
       end
     end

--- a/lib/scarlet/command.rb
+++ b/lib/scarlet/command.rb
@@ -115,6 +115,9 @@ class Scarlet
     class Callback
       include Scarlet::Loggable
 
+      # @return [Scarlet::Event]
+      attr_reader :event
+
       # Create a new callback instance,
       #
       # @param [Proc] block The block we want to call as a callback.

--- a/lib/scarlet/event.rb
+++ b/lib/scarlet/event.rb
@@ -5,7 +5,7 @@ require 'active_support/core_ext/module/delegation'
 # sent from, and what was sent.
 class Scarlet
   class Event
-    attr_accessor :server, :sender, :command, :params, :target, :channel, :return_path
+    attr_accessor :server, :sender, :command, :params, :target, :channel, :return_path, :data
 
     # Creates a new event that can then be distributed to the listeners.
     # @param [Server] server The server from which the event was sent.
@@ -24,6 +24,7 @@ class Scarlet
       @channel = target if target and target.start_with? '#'
       @return_path = @channel || @sender.nick
       @params = params
+      @data = {}
     end
 
     # Delegated back to +@server+.

--- a/lib/scarlet/plugins/command.rb
+++ b/lib/scarlet/plugins/command.rb
@@ -89,7 +89,7 @@ module Scarlet::Plugins
     # @param [String] command
     # @return [Array<Listener>]
     def match_commands command
-      select_commands { |c| c.usage.start_with? command }
+      select_commands { |c| c.usage.include? command }
     end
 
     # Returns help matching the specified string. If no command is used, then
@@ -121,7 +121,8 @@ module Scarlet::Plugins
       @listeners.keys.each do |key|
         key.match event.params.first do |matches|
           if check_access(event, @listeners[key].clearance)
-            @listeners[key].invoke event.dup, matches
+            ev = event.dup.tap { |ev| ev.data[:commands] = self }
+            @listeners[key].invoke ev, matches
           end
         end
       end


### PR DESCRIPTION
I've added a data attribute to Events to allow arbitrary data, to be carried by the event.

This restores the `reload command(s)` and `help` commands.