### PR TITLE
Double unescape google command links

### DIFF
--- a/commands/google.rb
+++ b/commands/google.rb
@@ -13,7 +13,7 @@ hear(/(?:g|google)\s+(?<query>.+)/) do
     http.callback do
       if value = http.response.value
         reply(if results = value['responseData']['results'].presence
-          URI.unescape(results.first['url'])
+          URI.unescape(URI.unescape(results.first['url']))
         else
           "No search result found."
         end)


### PR DESCRIPTION
```
# BEFORE
@g 暗殺教室 wiki 
https://zh-yue.wikipedia.org/wiki/Template_talk:%E6%9C%89%E5%91%A2%E7%89%88

# AFTER
@g 暗殺教室 wiki
https://zh-yue.wikipedia.org/wiki/Template_talk:有呢版
```