### PR TITLE
Fixed birthday command bugs and issues

### DIFF
--- a/commands/birthday.rb
+++ b/commands/birthday.rb
@@ -6,7 +6,7 @@ with_dob = lambda do |&block|
     if dob = nick.settings[:dob]
       instance_exec(dob, &block)
     else
-      if params[:nick] == nick.nick
+      if params[:nick] == sender.nick
         reply "You have not set your dob"
       else
         reply "#{nick.nick} has not set their dob"
@@ -15,21 +15,28 @@ with_dob = lambda do |&block|
   end
 end
 
-hear(/set my dob (?<year>\d+) (?<month>\d+) (?<day>\d+)/) do
+hear(/set\s+my\s+dob\s+(?<date>\S+)/) do
   clearance(&:registered?)
   description 'Sets your dob setting'
-  usage 'set my dob <year> <month> <day>'
+  usage 'set my dob <date>'
   on do
     with_nick sender.nick do |nick|
-      nick.update_settings(dob: Date.new(params[:year].to_i, params[:month].to_i, params[:day].to_i))
-      notify "Okay, I've set your dob to #{fmt.date(nick.settings[:dob])}"
+      date = begin
+        Date.parse(params[:date])
+      rescue ArgumentError => ex
+        error_reply ex.message
+      end
+      if date
+        nick.update_settings(dob: date)
+        notify "Okay, I've set your DOB to #{fmt.date(nick.settings[:dob])}"
+      end
     end
   end
 end
 
-hear(/birthday(?: (?<nick>\S+))?/) do
+hear(/birthday(?:\s+(?<nick>\S+))?/) do
   clearance nil
-  description "Displays a user's date of birth"
+  description "Displays a user's date of birth, or your own if no nick is given"
   usage 'birthday [<nick>]'
   on do
     with_nick params[:nick] || sender.nick do |nick|
@@ -40,7 +47,7 @@ hear(/birthday(?: (?<nick>\S+))?/) do
   end
 end
 
-hear(/age(?: (?<nick>\S+))?/) do
+hear(/age(?:\s+(?<nick>\S+))?/) do
   clearance nil
   description "Displays a user's age, or your own if no nick is given"
   usage 'age [<nick>]'


### PR DESCRIPTION
* Fixed user's with their dob not set displaying the wrong error message
* `set my dob` is now parsed using Date.parse
* Updated `birthday` description
* Allow spaces in age command